### PR TITLE
Update project URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     long_description=read('README.rst') + '\n\n' + read('CHANGELOG.rst'),
     author='Bernhard Janetzki',
     author_email='boerni@gmail.com',
-    url='https://github.com/ierror/django-js-reverse',
+    url='https://github.com/vintasoftware/django-js-reverse',
     download_url='http://pypi.python.org/pypi/django-js-reverse/',
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Change the project homepage URL in setup.py to the new GitHub organization